### PR TITLE
feat: implement comprehensive user profile system

### DIFF
--- a/src/main/java/com/wrappedup/backend/application/service/UserProfileServiceImpl.java
+++ b/src/main/java/com/wrappedup/backend/application/service/UserProfileServiceImpl.java
@@ -1,0 +1,113 @@
+package com.wrappedup.backend.application.service;
+
+import com.wrappedup.backend.domain.User;
+import com.wrappedup.backend.domain.UserProfile;
+import com.wrappedup.backend.domain.port.UserProfileRepository;
+import com.wrappedup.backend.domain.port.UserRepository;
+import com.wrappedup.backend.domain.port.UserProfileService;
+import com.wrappedup.backend.dto.UpdateUserProfileDto;
+import com.wrappedup.backend.dto.UserProfileDto;
+import com.wrappedup.backend.mapper.UserProfileMapper;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserProfileServiceImpl implements UserProfileService {
+    
+    private final UserProfileRepository userProfileRepository;
+    private final UserRepository userRepository;
+    private final UserProfileMapper userProfileMapper;
+    
+    @Override
+    @Transactional
+    public UserProfileDto updateProfile(UUID userId, UpdateUserProfileDto profileDto) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + userId));
+            
+        // Get existing profile or create a new one - use orElseGet instead of orElse
+        // to ensure the new UserProfile is only created if needed
+        UserProfile profile = userProfileRepository.findByUserId(userId)
+            .orElseGet(() -> new UserProfile(user));
+            
+        // Update profile fields
+        if (profileDto.getFullName() != null) {
+            profile.setFullName(profileDto.getFullName());
+        }
+        if (profileDto.getBio() != null) {
+            profile.setBio(profileDto.getBio());
+        }
+        if (profileDto.getUserImageUrl() != null) {
+            profile.setUserImageUrl(profileDto.getUserImageUrl());
+        }
+        if (profileDto.getFavoriteGenres() != null) {
+            profile.setFavoriteGenres(profileDto.getFavoriteGenres());
+        }
+        if (profileDto.getReadingGoal() != null) {
+            profile.setReadingGoal(profileDto.getReadingGoal());
+        }
+        if (profileDto.getPreferredLanguage() != null) {
+            profile.setPreferredLanguage(profileDto.getPreferredLanguage());
+        }
+        profile.setPublicProfile(profileDto.isPublicProfile());
+        if (profileDto.getSocialLinks() != null) {
+            profile.setSocialLinks(profileDto.getSocialLinks());
+        }
+        if (profileDto.getLocation() != null) {
+            profile.setLocation(profileDto.getLocation());
+        }
+        
+        // Save the profile once
+        UserProfile savedProfile = userProfileRepository.save(profile);
+        return userProfileMapper.toDto(savedProfile);
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<UserProfileDto> getProfile(UUID userId) {
+        return userProfileRepository.findByUserId(userId)
+            .map(userProfileMapper::toDto);
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<UserProfileDto> getPublicProfile(String username) {
+        log.debug("Looking for public profile for username: {}", username);
+        
+        // First try to find the user by username
+        Optional<User> user = userRepository.findByUsername(username);
+        if (user.isEmpty()) {
+            log.debug("User not found with username: {}", username);
+            return Optional.empty();
+        }
+        
+        // Then try to find their profile
+        Optional<UserProfile> profile = userProfileRepository.findByUserId(user.get().getId());
+        if (profile.isEmpty()) {
+            log.debug("No profile found for user: {}", username);
+            return Optional.empty();
+        }
+        
+        // Check if profile is public
+        if (!profile.get().isPublicProfile()) {
+            log.debug("Profile for user {} is private", username);
+            return Optional.empty();
+        }
+        
+        log.debug("Public profile found for username: {}", username);
+        return Optional.of(userProfileMapper.toDto(profile.get()));
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsByUserId(UUID userId) {
+        return userProfileRepository.existsByUserId(userId);
+    }
+} 

--- a/src/main/java/com/wrappedup/backend/domain/UserProfile.java
+++ b/src/main/java/com/wrappedup/backend/domain/UserProfile.java
@@ -1,0 +1,88 @@
+package com.wrappedup.backend.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.GenericGenerator;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_profiles")
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserProfile {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(name = "id", columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // Basic Information
+    @Column(length = 100)
+    private String fullName;
+
+    @Column(length = 500)
+    private String bio;
+
+    @Column(name = "user_image_url")
+    private String userImageUrl;
+
+    // Reading Preferences
+    @ElementCollection
+    @CollectionTable(name = "user_favorite_genres", joinColumns = @JoinColumn(name = "user_profile_id"))
+    @Column(name = "genre")
+    private List<String> favoriteGenres;
+
+    @Column(name = "reading_goal")
+    private Integer readingGoal;
+
+    @Column(name = "preferred_language")
+    private String preferredLanguage;
+
+    // Social Features
+    @Column(name = "is_public_profile")
+    private boolean isPublicProfile = true;
+
+    @ElementCollection
+    @CollectionTable(name = "user_social_links", joinColumns = @JoinColumn(name = "user_profile_id"))
+    @MapKeyColumn(name = "platform")
+    @Column(name = "url")
+    private Map<String, String> socialLinks;
+
+    private String location;
+
+    // Timestamps
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public UserProfile(User user) {
+        this.user = user;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+} 

--- a/src/main/java/com/wrappedup/backend/domain/port/UserProfileRepository.java
+++ b/src/main/java/com/wrappedup/backend/domain/port/UserProfileRepository.java
@@ -1,0 +1,14 @@
+package com.wrappedup.backend.domain.port;
+
+import com.wrappedup.backend.domain.UserProfile;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserProfileRepository {
+    UserProfile save(UserProfile profile);
+    Optional<UserProfile> findById(UUID id);
+    Optional<UserProfile> findByUserId(UUID userId);
+    Optional<UserProfile> findByUserUsername(String username);
+    void deleteById(UUID id);
+    boolean existsByUserId(UUID userId);
+} 

--- a/src/main/java/com/wrappedup/backend/domain/port/UserProfileService.java
+++ b/src/main/java/com/wrappedup/backend/domain/port/UserProfileService.java
@@ -1,0 +1,14 @@
+package com.wrappedup.backend.domain.port;
+
+import com.wrappedup.backend.domain.UserProfile;
+import com.wrappedup.backend.dto.UpdateUserProfileDto;
+import com.wrappedup.backend.dto.UserProfileDto;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserProfileService {
+    UserProfileDto updateProfile(UUID userId, UpdateUserProfileDto profileDto);
+    Optional<UserProfileDto> getProfile(UUID userId);
+    Optional<UserProfileDto> getPublicProfile(String username);
+    boolean existsByUserId(UUID userId);
+} 

--- a/src/main/java/com/wrappedup/backend/domain/port/UserRepository.java
+++ b/src/main/java/com/wrappedup/backend/domain/port/UserRepository.java
@@ -5,10 +5,10 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository {
-    User save(User user);
     Optional<User> findById(UUID id);
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
+    User save(User user);
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
 } 

--- a/src/main/java/com/wrappedup/backend/dto/UpdateUserProfileDto.java
+++ b/src/main/java/com/wrappedup/backend/dto/UpdateUserProfileDto.java
@@ -1,0 +1,39 @@
+package com.wrappedup.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class UpdateUserProfileDto {
+    @Size(max = 100)
+    private String fullName;
+    
+    @Size(max = 500)
+    private String bio;
+    
+    private String userImageUrl;
+    
+    // Reading Preferences
+    private List<String> favoriteGenres;
+    
+    private Integer readingGoal;
+    
+    private String preferredLanguage;
+    
+    // Social Features
+    @JsonProperty("isPublicProfile")
+    private boolean publicProfile;
+    
+    private Map<String, String> socialLinks;
+    
+    private String location;
+    
+    // Add this method for backward compatibility
+    public boolean isPublicProfile() {
+        return publicProfile;
+    }
+} 

--- a/src/main/java/com/wrappedup/backend/dto/UserProfileDto.java
+++ b/src/main/java/com/wrappedup/backend/dto/UserProfileDto.java
@@ -1,0 +1,55 @@
+package com.wrappedup.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class UserProfileDto {
+    // Basic Information
+    @NotBlank
+    private String username;
+    
+    @Email
+    @NotBlank
+    private String email;
+    
+    @Size(max = 100)
+    private String fullName;
+    
+    @Size(max = 500)
+    private String bio;
+    
+    private String userImageUrl;
+    
+    // Reading Preferences
+    private List<String> favoriteGenres;
+    
+    private Integer readingGoal;
+    
+    private String preferredLanguage;
+    
+    // Social Features
+    @JsonProperty("isPublicProfile")
+    private boolean publicProfile;
+    
+    private Map<String, String> socialLinks;
+    
+    private String location;
+    
+    // Timestamps
+    private LocalDateTime createdAt;
+    
+    private LocalDateTime updatedAt;
+    
+    // Add this method for backward compatibility
+    public boolean isPublicProfile() {
+        return publicProfile;
+    }
+} 

--- a/src/main/java/com/wrappedup/backend/infrastructure/adapter/jpa/JpaUserProfileRepository.java
+++ b/src/main/java/com/wrappedup/backend/infrastructure/adapter/jpa/JpaUserProfileRepository.java
@@ -1,0 +1,46 @@
+package com.wrappedup.backend.infrastructure.adapter.jpa;
+
+import com.wrappedup.backend.domain.UserProfile;
+import com.wrappedup.backend.domain.port.UserProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaUserProfileRepository implements UserProfileRepository {
+    
+    private final SpringDataUserProfileRepository springDataUserProfileRepository;
+
+    @Override
+    public UserProfile save(UserProfile profile) {
+        return springDataUserProfileRepository.save(profile);
+    }
+
+    @Override
+    public Optional<UserProfile> findById(UUID id) {
+        return springDataUserProfileRepository.findById(id);
+    }
+
+    @Override
+    public Optional<UserProfile> findByUserId(UUID userId) {
+        return springDataUserProfileRepository.findByUserId(userId);
+    }
+
+    @Override
+    public Optional<UserProfile> findByUserUsername(String username) {
+        return springDataUserProfileRepository.findByUserUsername(username);
+    }
+
+    @Override
+    public boolean existsByUserId(UUID userId) {
+        return springDataUserProfileRepository.existsByUserId(userId);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        springDataUserProfileRepository.deleteById(id);
+    }
+} 

--- a/src/main/java/com/wrappedup/backend/infrastructure/adapter/jpa/SpringDataUserProfileRepository.java
+++ b/src/main/java/com/wrappedup/backend/infrastructure/adapter/jpa/SpringDataUserProfileRepository.java
@@ -1,0 +1,15 @@
+package com.wrappedup.backend.infrastructure.adapter.jpa;
+
+import com.wrappedup.backend.domain.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface SpringDataUserProfileRepository extends JpaRepository<UserProfile, UUID> {
+    Optional<UserProfile> findByUserId(UUID userId);
+    Optional<UserProfile> findByUserUsername(String username);
+    boolean existsByUserId(UUID userId);
+} 

--- a/src/main/java/com/wrappedup/backend/infrastructure/controller/UserProfileController.java
+++ b/src/main/java/com/wrappedup/backend/infrastructure/controller/UserProfileController.java
@@ -1,0 +1,42 @@
+package com.wrappedup.backend.infrastructure.controller;
+
+import com.wrappedup.backend.domain.User;
+import com.wrappedup.backend.domain.port.UserProfileService;
+import com.wrappedup.backend.dto.UpdateUserProfileDto;
+import com.wrappedup.backend.dto.UserProfileDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/profiles")
+@RequiredArgsConstructor
+public class UserProfileController {
+    
+    private final UserProfileService userProfileService;
+    
+    @PutMapping
+    public ResponseEntity<UserProfileDto> updateProfile(
+            @Valid @RequestBody UpdateUserProfileDto profileDto,
+            @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(userProfileService.updateProfile(user.getId(), profileDto));
+    }
+    
+    @GetMapping
+    public ResponseEntity<UserProfileDto> getProfile(@AuthenticationPrincipal User user) {
+        return userProfileService.getProfile(user.getId())
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.notFound().build());
+    }
+    
+    @GetMapping("/public/{username}")
+    public ResponseEntity<UserProfileDto> getPublicProfile(@PathVariable String username) {
+        return userProfileService.getPublicProfile(username)
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.notFound().build());
+    }
+} 

--- a/src/main/java/com/wrappedup/backend/infrastructure/security/AuthenticationService.java
+++ b/src/main/java/com/wrappedup/backend/infrastructure/security/AuthenticationService.java
@@ -1,6 +1,8 @@
 package com.wrappedup.backend.infrastructure.security;
 
 import com.wrappedup.backend.domain.User;
+import com.wrappedup.backend.domain.UserProfile;
+import com.wrappedup.backend.domain.port.UserProfileRepository;
 import com.wrappedup.backend.domain.port.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,16 +10,22 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthenticationService {
     private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;
 
+    @Transactional
     public AuthenticationResponse register(RegisterRequest request) {
         var user = new User(
             request.username(),
@@ -26,6 +34,21 @@ public class AuthenticationService {
         );
         
         user = userRepository.save(user);
+        
+        // Create default profile
+        UserProfile profile = new UserProfile(user);
+        profile.setFullName(request.username()); // Default to username
+        profile.setBio(""); // Empty bio
+        profile.setFavoriteGenres(new ArrayList<>()); // Empty genres
+        profile.setReadingGoal(12); // Default: 1 book per month
+        profile.setPreferredLanguage("English"); // Default language
+        profile.setPublicProfile(true); // Public by default
+        profile.setSocialLinks(new HashMap<>()); // Empty social links
+        
+        userProfileRepository.save(profile);
+        
+        log.info("Created default profile for user: {}", user.getId());
+        
         var token = jwtService.generateToken(user);
         
         return AuthenticationResponse.of(

--- a/src/main/java/com/wrappedup/backend/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/wrappedup/backend/infrastructure/security/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/api/auth/register", "/api/auth/authenticate").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/auth/me").authenticated()
                 .requestMatchers(HttpMethod.GET, "/api/wishlist/public/user/*").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/profiles/public/*").permitAll()
                 .requestMatchers("/error").permitAll()
                 .requestMatchers("/status").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/books").authenticated()

--- a/src/main/java/com/wrappedup/backend/mapper/UserProfileMapper.java
+++ b/src/main/java/com/wrappedup/backend/mapper/UserProfileMapper.java
@@ -1,0 +1,93 @@
+package com.wrappedup.backend.mapper;
+
+import com.wrappedup.backend.domain.User;
+import com.wrappedup.backend.domain.UserProfile;
+import com.wrappedup.backend.dto.UpdateUserProfileDto;
+import com.wrappedup.backend.dto.UserProfileDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserProfileMapper {
+    
+    public UserProfileDto toDto(UserProfile profile) {
+        if (profile == null) {
+            return null;
+        }
+        
+        UserProfileDto dto = new UserProfileDto();
+        User user = profile.getUser();
+        
+        // Basic Information
+        dto.setUsername(user.getRealUsername());
+        dto.setEmail(user.getEmail());
+        dto.setFullName(profile.getFullName());
+        dto.setBio(profile.getBio());
+        dto.setUserImageUrl(profile.getUserImageUrl());
+        
+        // Reading Preferences
+        dto.setFavoriteGenres(profile.getFavoriteGenres());
+        dto.setReadingGoal(profile.getReadingGoal());
+        dto.setPreferredLanguage(profile.getPreferredLanguage());
+        
+        // Social Features
+        dto.setPublicProfile(profile.isPublicProfile());
+        dto.setSocialLinks(profile.getSocialLinks());
+        dto.setLocation(profile.getLocation());
+        
+        // Timestamps
+        dto.setCreatedAt(profile.getCreatedAt());
+        dto.setUpdatedAt(profile.getUpdatedAt());
+        
+        return dto;
+    }
+    
+    public UserProfile toEntity(UserProfileDto dto, User user) {
+        if (dto == null) {
+            return null;
+        }
+        
+        UserProfile profile = new UserProfile(user);
+        
+        // Basic Information
+        profile.setFullName(dto.getFullName());
+        profile.setBio(dto.getBio());
+        profile.setUserImageUrl(dto.getUserImageUrl());
+        
+        // Reading Preferences
+        profile.setFavoriteGenres(dto.getFavoriteGenres());
+        profile.setReadingGoal(dto.getReadingGoal());
+        profile.setPreferredLanguage(dto.getPreferredLanguage());
+        
+        // Social Features
+        profile.setPublicProfile(dto.isPublicProfile());
+        profile.setSocialLinks(dto.getSocialLinks());
+        profile.setLocation(dto.getLocation());
+        
+        return profile;
+    }
+    
+    public UserProfile toEntity(UpdateUserProfileDto dto, User user) {
+        if (dto == null) {
+            return null;
+        }
+        
+        UserProfile profile = new UserProfile(user);
+        
+        // Basic Information
+        profile.setFullName(dto.getFullName());
+        profile.setBio(dto.getBio());
+        profile.setUserImageUrl(dto.getUserImageUrl());
+        
+        // Reading Preferences
+        profile.setFavoriteGenres(dto.getFavoriteGenres());
+        profile.setReadingGoal(dto.getReadingGoal());
+        profile.setPreferredLanguage(dto.getPreferredLanguage());
+        
+        // Social Features
+        profile.setPublicProfile(dto.isPublicProfile());
+        profile.setSocialLinks(dto.getSocialLinks());
+        profile.setLocation(dto.getLocation());
+        
+        return profile;
+    }
+} 

--- a/src/test/java/com/wrappedup/backend/application/service/UserProfileServiceImplTest.java
+++ b/src/test/java/com/wrappedup/backend/application/service/UserProfileServiceImplTest.java
@@ -1,0 +1,270 @@
+package com.wrappedup.backend.application.service;
+
+import com.wrappedup.backend.domain.User;
+import com.wrappedup.backend.domain.UserProfile;
+import com.wrappedup.backend.domain.port.UserProfileRepository;
+import com.wrappedup.backend.domain.port.UserRepository;
+import com.wrappedup.backend.dto.UpdateUserProfileDto;
+import com.wrappedup.backend.dto.UserProfileDto;
+import com.wrappedup.backend.mapper.UserProfileMapper;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class UserProfileServiceImplTest {
+
+    private static final UUID TEST_USER_ID = UUID.fromString("f2295dea-c8cb-4493-ae1c-dbfebbfc4f3a");
+    private static final UUID TEST_PROFILE_ID = UUID.fromString("a1234567-e89b-12d3-a456-426614174000");
+    private static final String TEST_USERNAME = "testuser";
+    private static final String TEST_EMAIL = "test@example.com";
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserProfileMapper userProfileMapper;
+
+    @InjectMocks
+    private UserProfileServiceImpl userProfileService;
+
+    private User testUser;
+    private UserProfile testProfile;
+    private UserProfileDto testProfileDto;
+    private UpdateUserProfileDto updateProfileDto;
+
+    @BeforeEach
+    void setUp() {
+        // Setup test user
+        testUser = new User(TEST_USERNAME, TEST_EMAIL, "password");
+        testUser.setId(TEST_USER_ID);
+
+        // Setup test profile
+        testProfile = new UserProfile(testUser);
+        testProfile.setId(TEST_PROFILE_ID);
+        testProfile.setFullName("Test User");
+        testProfile.setBio("This is a test bio");
+        testProfile.setUserImageUrl("https://example.com/image.jpg");
+        testProfile.setFavoriteGenres(List.of("Fantasy", "Science Fiction"));
+        testProfile.setReadingGoal(50);
+        testProfile.setPreferredLanguage("English");
+        testProfile.setPublicProfile(true);
+        Map<String, String> socialLinks = new HashMap<>();
+        socialLinks.put("twitter", "https://twitter.com/testuser");
+        testProfile.setSocialLinks(socialLinks);
+        testProfile.setLocation("Test City");
+
+        // Setup test profile DTO
+        testProfileDto = new UserProfileDto();
+        testProfileDto.setUsername(TEST_USERNAME);
+        testProfileDto.setEmail(TEST_EMAIL);
+        testProfileDto.setFullName("Test User");
+        testProfileDto.setBio("This is a test bio");
+        testProfileDto.setUserImageUrl("https://example.com/image.jpg");
+        testProfileDto.setFavoriteGenres(List.of("Fantasy", "Science Fiction"));
+        testProfileDto.setReadingGoal(50);
+        testProfileDto.setPreferredLanguage("English");
+        testProfileDto.setPublicProfile(true);
+        testProfileDto.setSocialLinks(socialLinks);
+        testProfileDto.setLocation("Test City");
+
+        // Setup update profile DTO
+        updateProfileDto = new UpdateUserProfileDto();
+        updateProfileDto.setFullName("Updated Name");
+        updateProfileDto.setBio("Updated bio");
+        updateProfileDto.setUserImageUrl("https://example.com/updated.jpg");
+        updateProfileDto.setFavoriteGenres(List.of("Mystery", "Thriller"));
+        updateProfileDto.setReadingGoal(75);
+        updateProfileDto.setPreferredLanguage("Spanish");
+        updateProfileDto.setPublicProfile(true);
+        Map<String, String> updatedLinks = new HashMap<>();
+        updatedLinks.put("instagram", "https://instagram.com/testuser");
+        updateProfileDto.setSocialLinks(updatedLinks);
+        updateProfileDto.setLocation("Updated City");
+
+        // Configure mocks
+        when(userRepository.findById(TEST_USER_ID)).thenReturn(Optional.of(testUser));
+        when(userProfileMapper.toDto(any(UserProfile.class))).thenReturn(testProfileDto);
+    }
+
+    @Test
+    void shouldUpdateExistingProfile() {
+        // Given
+        when(userProfileRepository.findByUserId(TEST_USER_ID)).thenReturn(Optional.of(testProfile));
+        when(userProfileRepository.save(any(UserProfile.class))).thenReturn(testProfile);
+
+        // When
+        UserProfileDto result = userProfileService.updateProfile(TEST_USER_ID, updateProfileDto);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(TEST_USERNAME, result.getUsername());
+        assertEquals(TEST_EMAIL, result.getEmail());
+        
+        // Verify interactions
+        verify(userRepository).findById(TEST_USER_ID);
+        verify(userProfileRepository).findByUserId(TEST_USER_ID);
+        verify(userProfileRepository).save(any(UserProfile.class));
+        verify(userProfileMapper).toDto(testProfile);
+    }
+
+    @Test
+    void shouldCreateNewProfileWhenUpdatingNonExistentProfile() {
+        // Given
+        when(userProfileRepository.findByUserId(TEST_USER_ID)).thenReturn(Optional.empty());
+        
+        UserProfile newProfile = new UserProfile(testUser);
+        when(userProfileRepository.save(any(UserProfile.class))).thenReturn(newProfile);
+
+        // When
+        UserProfileDto result = userProfileService.updateProfile(TEST_USER_ID, updateProfileDto);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(TEST_USERNAME, result.getUsername());
+        assertEquals(TEST_EMAIL, result.getEmail());
+        
+        verify(userRepository).findById(TEST_USER_ID);
+        verify(userProfileRepository).findByUserId(TEST_USER_ID);
+        verify(userProfileRepository, times(1)).save(any(UserProfile.class));
+        verify(userProfileMapper).toDto(any(UserProfile.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUserNotFound() {
+        // Given
+        when(userRepository.findById(TEST_USER_ID)).thenReturn(Optional.empty());
+
+        // When & Then
+        EntityNotFoundException exception = assertThrows(
+                EntityNotFoundException.class,
+                () -> userProfileService.updateProfile(TEST_USER_ID, updateProfileDto)
+        );
+        assertTrue(exception.getMessage().contains("User not found"));
+        
+        // Verify interactions
+        verify(userRepository).findById(TEST_USER_ID);
+        verify(userProfileRepository, never()).save(any(UserProfile.class));
+    }
+
+    @Test
+    void shouldGetProfile() {
+        // Given
+        when(userProfileRepository.findByUserId(TEST_USER_ID)).thenReturn(Optional.of(testProfile));
+
+        // When
+        Optional<UserProfileDto> result = userProfileService.getProfile(TEST_USER_ID);
+
+        // Then
+        assertTrue(result.isPresent());
+        assertEquals(TEST_USERNAME, result.get().getUsername());
+        assertEquals(TEST_EMAIL, result.get().getEmail());
+        
+        // Verify interactions
+        verify(userProfileRepository).findByUserId(TEST_USER_ID);
+        verify(userProfileMapper).toDto(testProfile);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenProfileNotFound() {
+        // Given
+        when(userProfileRepository.findByUserId(TEST_USER_ID)).thenReturn(Optional.empty());
+
+        // When
+        Optional<UserProfileDto> result = userProfileService.getProfile(TEST_USER_ID);
+
+        // Then
+        assertFalse(result.isPresent());
+        
+        // Verify interactions
+        verify(userProfileRepository).findByUserId(TEST_USER_ID);
+        verify(userProfileMapper, never()).toDto(any());
+    }
+
+    @Test
+    void shouldGetPublicProfile() {
+        // Given
+        when(userRepository.findByUsername(TEST_USERNAME)).thenReturn(Optional.of(testUser));
+        when(userProfileRepository.findByUserId(TEST_USER_ID)).thenReturn(Optional.of(testProfile));
+
+        // When
+        Optional<UserProfileDto> result = userProfileService.getPublicProfile(TEST_USERNAME);
+
+        // Then
+        assertTrue(result.isPresent());
+        assertEquals(TEST_USERNAME, result.get().getUsername());
+        assertEquals(TEST_EMAIL, result.get().getEmail());
+        
+        // Verify interactions
+        verify(userRepository).findByUsername(TEST_USERNAME);
+        verify(userProfileRepository).findByUserId(TEST_USER_ID);
+        verify(userProfileMapper).toDto(testProfile);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenPublicProfileNotFound() {
+        // Given
+        when(userRepository.findByUsername(TEST_USERNAME)).thenReturn(Optional.empty());
+
+        // When
+        Optional<UserProfileDto> result = userProfileService.getPublicProfile(TEST_USERNAME);
+
+        // Then
+        assertFalse(result.isPresent());
+        
+        // Verify interactions
+        verify(userRepository).findByUsername(TEST_USERNAME);
+        verify(userProfileRepository, never()).findByUserId(any());
+        verify(userProfileMapper, never()).toDto(any());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenProfileIsPrivate() {
+        // Given
+        testProfile.setPublicProfile(false);
+        when(userRepository.findByUsername(TEST_USERNAME)).thenReturn(Optional.of(testUser));
+        when(userProfileRepository.findByUserId(TEST_USER_ID)).thenReturn(Optional.of(testProfile));
+
+        // When
+        Optional<UserProfileDto> result = userProfileService.getPublicProfile(TEST_USERNAME);
+
+        // Then
+        assertFalse(result.isPresent());
+        
+        // Verify interactions
+        verify(userRepository).findByUsername(TEST_USERNAME);
+        verify(userProfileRepository).findByUserId(TEST_USER_ID);
+        verify(userProfileMapper, never()).toDto(any());
+    }
+
+    @Test
+    void shouldCheckIfProfileExistsByUserId() {
+        // Given
+        when(userProfileRepository.existsByUserId(TEST_USER_ID)).thenReturn(true);
+
+        // When
+        boolean result = userProfileService.existsByUserId(TEST_USER_ID);
+
+        // Then
+        assertTrue(result);
+        
+        // Verify interactions
+        verify(userProfileRepository).existsByUserId(TEST_USER_ID);
+    }
+} 

--- a/src/test/java/com/wrappedup/backend/infrastructure/adapter/jpa/JpaUserProfileRepositoryTest.java
+++ b/src/test/java/com/wrappedup/backend/infrastructure/adapter/jpa/JpaUserProfileRepositoryTest.java
@@ -1,0 +1,188 @@
+package com.wrappedup.backend.infrastructure.adapter.jpa;
+
+import com.wrappedup.backend.domain.User;
+import com.wrappedup.backend.domain.UserProfile;
+import com.wrappedup.backend.domain.port.UserProfileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({JpaUserProfileRepository.class})
+class JpaUserProfileRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private UserProfileRepository userProfileRepository;
+
+    private User testUser;
+    private UserProfile testProfile;
+    private UUID testUserId;
+
+    @BeforeEach
+    void setUp() {
+        // Create and persist test user
+        testUser = new User("testuser", "test@example.com", "password");
+        testUser = entityManager.persistAndFlush(testUser);
+        testUserId = testUser.getId();
+
+        // Create and persist test profile
+        testProfile = new UserProfile(testUser);
+        testProfile.setFullName("Test User");
+        testProfile.setBio("This is a test bio");
+        testProfile.setUserImageUrl("https://example.com/image.jpg");
+        
+        // Use mutable collections instead of immutable ones
+        List<String> genres = new ArrayList<>();
+        genres.add("Fantasy");
+        genres.add("Science Fiction");
+        testProfile.setFavoriteGenres(genres);
+        
+        testProfile.setReadingGoal(50);
+        testProfile.setPreferredLanguage("English");
+        testProfile.setPublicProfile(true);
+        
+        Map<String, String> socialLinks = new HashMap<>();
+        socialLinks.put("twitter", "https://twitter.com/testuser");
+        testProfile.setSocialLinks(socialLinks);
+        testProfile.setLocation("Test City");
+        
+        testProfile = entityManager.persistAndFlush(testProfile);
+    }
+
+    @Test
+    void shouldFindByUserId() {
+        // When
+        Optional<UserProfile> foundProfile = userProfileRepository.findByUserId(testUserId);
+        
+        // Then
+        assertTrue(foundProfile.isPresent());
+        assertEquals(testProfile.getId(), foundProfile.get().getId());
+        assertEquals("Test User", foundProfile.get().getFullName());
+        assertEquals("This is a test bio", foundProfile.get().getBio());
+        assertEquals(testUser.getId(), foundProfile.get().getUser().getId());
+    }
+    
+    @Test
+    void shouldReturnEmptyWhenFindingByNonExistentUserId() {
+        // When
+        Optional<UserProfile> foundProfile = userProfileRepository.findByUserId(UUID.randomUUID());
+        
+        // Then
+        assertFalse(foundProfile.isPresent());
+    }
+
+    @Test
+    void shouldFindByUserUsername() {
+        // When
+        Optional<UserProfile> foundProfile = userProfileRepository.findByUserUsername("testuser");
+        
+        // Then
+        assertTrue(foundProfile.isPresent());
+        assertEquals(testProfile.getId(), foundProfile.get().getId());
+        assertEquals("Test User", foundProfile.get().getFullName());
+    }
+    
+    @Test
+    void shouldReturnEmptyWhenFindingByNonExistentUsername() {
+        // When
+        Optional<UserProfile> foundProfile = userProfileRepository.findByUserUsername("nonexistentuser");
+        
+        // Then
+        assertFalse(foundProfile.isPresent());
+    }
+
+    @Test
+    void shouldCheckIfExistsByUserId() {
+        // When
+        boolean exists = userProfileRepository.existsByUserId(testUserId);
+        
+        // Then
+        assertTrue(exists);
+    }
+    
+    @Test
+    void shouldReturnFalseWhenCheckingExistenceForNonExistentUserId() {
+        // When
+        boolean exists = userProfileRepository.existsByUserId(UUID.randomUUID());
+        
+        // Then
+        assertFalse(exists);
+    }
+
+    @Test
+    void shouldSaveProfile() {
+        // Given
+        User newUser = new User("newuser", "new@example.com", "password");
+        newUser = entityManager.persistAndFlush(newUser);
+        
+        UserProfile newProfile = new UserProfile(newUser);
+        newProfile.setFullName("New User");
+        newProfile.setBio("New user bio");
+        
+        // When
+        UserProfile savedProfile = userProfileRepository.save(newProfile);
+        entityManager.flush();
+        entityManager.clear();
+        
+        // Then
+        assertNotNull(savedProfile.getId());
+        
+        Optional<UserProfile> foundProfile = userProfileRepository.findById(savedProfile.getId());
+        assertTrue(foundProfile.isPresent());
+        assertEquals("New User", foundProfile.get().getFullName());
+        assertEquals("New user bio", foundProfile.get().getBio());
+    }
+
+    @Test
+    void shouldDeleteProfile() {
+        // When
+        userProfileRepository.deleteById(testProfile.getId());
+        entityManager.flush();
+        entityManager.clear();
+        
+        // Then
+        Optional<UserProfile> foundProfile = userProfileRepository.findById(testProfile.getId());
+        assertFalse(foundProfile.isPresent());
+    }
+
+    @Test
+    void shouldUpdateProfile() {
+        // Given
+        testProfile.setFullName("Updated Name");
+        testProfile.setBio("Updated bio");
+        testProfile.setPublicProfile(false);
+        
+        // Use mutable collections for the update
+        List<String> updatedGenres = new ArrayList<>();
+        updatedGenres.add("Mystery");
+        updatedGenres.add("Thriller");
+        testProfile.setFavoriteGenres(updatedGenres);
+        
+        // When
+        UserProfile updatedProfile = userProfileRepository.save(testProfile);
+        entityManager.flush();
+        entityManager.clear();
+        
+        // Then
+        Optional<UserProfile> foundProfile = userProfileRepository.findById(testProfile.getId());
+        assertTrue(foundProfile.isPresent());
+        assertEquals("Updated Name", foundProfile.get().getFullName());
+        assertEquals("Updated bio", foundProfile.get().getBio());
+        assertFalse(foundProfile.get().isPublicProfile());
+        assertEquals(2, foundProfile.get().getFavoriteGenres().size());
+        assertTrue(foundProfile.get().getFavoriteGenres().contains("Mystery"));
+        assertTrue(foundProfile.get().getFavoriteGenres().contains("Thriller"));
+    }
+} 

--- a/src/test/java/com/wrappedup/backend/infrastructure/controller/UserProfileControllerTest.java
+++ b/src/test/java/com/wrappedup/backend/infrastructure/controller/UserProfileControllerTest.java
@@ -1,0 +1,191 @@
+package com.wrappedup.backend.infrastructure.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wrappedup.backend.domain.Role;
+import com.wrappedup.backend.domain.User;
+import com.wrappedup.backend.domain.port.UserProfileService;
+import com.wrappedup.backend.dto.UpdateUserProfileDto;
+import com.wrappedup.backend.dto.UserProfileDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserProfileControllerTest {
+
+    private static final UUID TEST_USER_ID = UUID.fromString("f2295dea-c8cb-4493-ae1c-dbfebbfc4f3a");
+    private static final String TEST_USERNAME = "testuser";
+    private static final String TEST_EMAIL = "test@example.com";
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserProfileService userProfileService;
+
+    private User testUser;
+    private UserProfileDto testProfileDto;
+    private UpdateUserProfileDto updateProfileDto;
+
+    @BeforeEach
+    public void setup() {
+        // Create test user
+        testUser = new User(TEST_USERNAME, TEST_EMAIL, "password");
+        testUser.setId(TEST_USER_ID);
+        testUser.setRole(Role.USER);
+        testUser.setEnabled(true);
+
+        // Create test profile DTO
+        testProfileDto = new UserProfileDto();
+        testProfileDto.setUsername(TEST_USERNAME);
+        testProfileDto.setEmail(TEST_EMAIL);
+        testProfileDto.setFullName("Test User");
+        testProfileDto.setBio("This is a test bio");
+        testProfileDto.setUserImageUrl("https://example.com/image.jpg");
+        testProfileDto.setFavoriteGenres(List.of("Fantasy", "Science Fiction"));
+        testProfileDto.setReadingGoal(50);
+        testProfileDto.setPreferredLanguage("English");
+        testProfileDto.setPublicProfile(true);
+        Map<String, String> socialLinks = new HashMap<>();
+        socialLinks.put("twitter", "https://twitter.com/testuser");
+        testProfileDto.setSocialLinks(socialLinks);
+        testProfileDto.setLocation("Test City");
+        testProfileDto.setCreatedAt(LocalDateTime.now());
+        testProfileDto.setUpdatedAt(LocalDateTime.now());
+
+        // Create update profile DTO
+        updateProfileDto = new UpdateUserProfileDto();
+        updateProfileDto.setFullName("Updated Name");
+        updateProfileDto.setBio("Updated bio");
+        updateProfileDto.setUserImageUrl("https://example.com/updated.jpg");
+        updateProfileDto.setFavoriteGenres(List.of("Mystery", "Thriller"));
+        updateProfileDto.setReadingGoal(75);
+        updateProfileDto.setPreferredLanguage("Spanish");
+        updateProfileDto.setPublicProfile(true);
+        Map<String, String> updatedLinks = new HashMap<>();
+        updatedLinks.put("instagram", "https://instagram.com/testuser");
+        updateProfileDto.setSocialLinks(updatedLinks);
+        updateProfileDto.setLocation("Updated City");
+
+        // Set up the security context with the test user
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+            testUser, null, testUser.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(context)
+            .apply(SecurityMockMvcConfigurers.springSecurity())
+            .build();
+    }
+
+    @Test
+    @WithMockUser(username = "test@example.com")
+    void shouldGetUserProfile() throws Exception {
+        // Given
+        when(userProfileService.getProfile(TEST_USER_ID)).thenReturn(Optional.of(testProfileDto));
+
+        // When & Then
+        mockMvc.perform(get("/api/profiles")
+                .contentType(MediaType.APPLICATION_JSON)
+                .principal(new UsernamePasswordAuthenticationToken(testUser, null, testUser.getAuthorities())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value(TEST_USERNAME))
+                .andExpect(jsonPath("$.email").value(TEST_EMAIL))
+                .andExpect(jsonPath("$.fullName").value("Test User"))
+                .andExpect(jsonPath("$.bio").value("This is a test bio"))
+                .andExpect(jsonPath("$.favoriteGenres[0]").value("Fantasy"))
+                .andExpect(jsonPath("$.favoriteGenres[1]").value("Science Fiction"))
+                .andExpect(jsonPath("$.readingGoal").value(50))
+                .andExpect(jsonPath("$.preferredLanguage").value("English"))
+                .andExpect(jsonPath("$.isPublicProfile").value(true))
+                .andExpect(jsonPath("$.socialLinks.twitter").value("https://twitter.com/testuser"))
+                .andExpect(jsonPath("$.location").value("Test City"));
+    }
+
+    @Test
+    @WithMockUser(username = "test@example.com")
+    void shouldReturn404WhenUserProfileNotFound() throws Exception {
+        // Given
+        when(userProfileService.getProfile(TEST_USER_ID)).thenReturn(Optional.empty());
+
+        // When & Then
+        mockMvc.perform(get("/api/profiles")
+                .contentType(MediaType.APPLICATION_JSON)
+                .principal(new UsernamePasswordAuthenticationToken(testUser, null, testUser.getAuthorities())))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "test@example.com")
+    void shouldUpdateUserProfile() throws Exception {
+        // Given
+        when(userProfileService.updateProfile(eq(TEST_USER_ID), any(UpdateUserProfileDto.class)))
+                .thenReturn(testProfileDto);
+
+        // When & Then
+        mockMvc.perform(put("/api/profiles")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateProfileDto))
+                .principal(new UsernamePasswordAuthenticationToken(testUser, null, testUser.getAuthorities())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value(TEST_USERNAME))
+                .andExpect(jsonPath("$.email").value(TEST_EMAIL));
+    }
+
+    @Test
+    void shouldGetPublicProfile() throws Exception {
+        // Given
+        when(userProfileService.getPublicProfile(TEST_USERNAME)).thenReturn(Optional.of(testProfileDto));
+
+        // When & Then
+        mockMvc.perform(get("/api/profiles/public/{username}", TEST_USERNAME)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value(TEST_USERNAME))
+                .andExpect(jsonPath("$.email").value(TEST_EMAIL))
+                .andExpect(jsonPath("$.fullName").value("Test User"))
+                .andExpect(jsonPath("$.isPublicProfile").value(true));
+    }
+
+    @Test
+    void shouldReturn404WhenPublicProfileNotFound() throws Exception {
+        // Given
+        when(userProfileService.getPublicProfile(TEST_USERNAME)).thenReturn(Optional.empty());
+
+        // When & Then
+        mockMvc.perform(get("/api/profiles/public/{username}", TEST_USERNAME)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+} 


### PR DESCRIPTION
This commit introduces a complete user profile management system:

- Add UserProfile entity with fields for basic info, reading preferences, and social features
- Create UserProfileDto and UpdateUserProfileDto for data transfer
- Implement UserProfileMapper for entity-DTO conversion
- Develop UserProfileRepository interface and JPA implementation
- Implement UserProfileService with methods for profile management
- Add REST endpoints for profile operations in UserProfileController
- Set up proper authorization for private and public profiles
- Support retrieving public profiles by username
- Implement profile updates with partial fields
- Create comprehensive test suite with unit and integration tests

Fix implementation issues:
- Resolve JSON serialization of publicProfile field with @JsonProperty annotation
- Fix collection handling using mutable lists instead of immutable List.of()
- Optimize service implementation to avoid duplicate save operations
- Ensure consistent naming and behavior across all components

The system now handles user profiles with appropriate access control, allowing users to maintain their own profiles while making public profiles accessible to all users.